### PR TITLE
Implement infinite scroll

### DIFF
--- a/app/src/main/java/com/halil/ozel/unsplashexample/api/ImageService.kt
+++ b/app/src/main/java/com/halil/ozel/unsplashexample/api/ImageService.kt
@@ -6,12 +6,17 @@ import com.halil.ozel.unsplashexample.utils.Constants.AUTHORIZATION
 import com.halil.ozel.unsplashexample.utils.Constants.CLIENT_ID
 import com.halil.ozel.unsplashexample.utils.Constants.END_POINT
 import com.halil.ozel.unsplashexample.utils.Constants.VERSION
+import com.halil.ozel.unsplashexample.utils.Constants.PER_PAGE
 import retrofit2.Response
 import retrofit2.http.GET
 import retrofit2.http.Headers
+import retrofit2.http.Query
 
 interface ImageService {
     @Headers("$ACCEPT_VERSION: $VERSION", "$AUTHORIZATION $CLIENT_ID")
     @GET(END_POINT)
-    suspend fun getAllImages(): Response<List<ImageItem>>
+    suspend fun getImages(
+        @Query("page") page: Int,
+        @Query("per_page") perPage: Int = PER_PAGE
+    ): Response<List<ImageItem>>
 }

--- a/app/src/main/java/com/halil/ozel/unsplashexample/repository/ImageRepository.kt
+++ b/app/src/main/java/com/halil/ozel/unsplashexample/repository/ImageRepository.kt
@@ -4,5 +4,5 @@ import com.halil.ozel.unsplashexample.api.ImageService
 import javax.inject.Inject
 
 class ImageRepository @Inject constructor(private val api: ImageService) {
-    suspend fun getAllImages() = api.getAllImages()
+    suspend fun getImages(page: Int) = api.getImages(page)
 }

--- a/app/src/main/java/com/halil/ozel/unsplashexample/ui/activity/MainActivity.kt
+++ b/app/src/main/java/com/halil/ozel/unsplashexample/ui/activity/MainActivity.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
 import com.halil.ozel.unsplashexample.databinding.ActivityMainBinding
 import com.halil.ozel.unsplashexample.ui.adapter.ImageAdapter
 import com.halil.ozel.unsplashexample.ui.viewmodel.ImageViewModel
@@ -13,6 +14,7 @@ import dagger.hilt.android.AndroidEntryPoint
 class MainActivity : AppCompatActivity() {
     private lateinit var binding: ActivityMainBinding
     private val imageAdapter = ImageAdapter()
+    private lateinit var layoutManager: LinearLayoutManager
     private val viewModel: ImageViewModel by viewModels()
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -26,8 +28,23 @@ class MainActivity : AppCompatActivity() {
         setContentView(binding.root)
         binding.recyclerView.apply {
             adapter = imageAdapter
-            layoutManager = LinearLayoutManager(this@MainActivity)
+            layoutManager = LinearLayoutManager(this@MainActivity).also {
+                this@MainActivity.layoutManager = it
+            }
             setHasFixedSize(true)
+            addOnScrollListener(object : RecyclerView.OnScrollListener() {
+                override fun onScrolled(recyclerView: RecyclerView, dx: Int, dy: Int) {
+                    super.onScrolled(recyclerView, dx, dy)
+                    if (dy > 0) {
+                        val visibleItemCount = layoutManager.childCount
+                        val totalItemCount = layoutManager.itemCount
+                        val pastVisibleItems = layoutManager.findFirstVisibleItemPosition()
+                        if (visibleItemCount + pastVisibleItems >= totalItemCount) {
+                            viewModel.loadNextPage()
+                        }
+                    }
+                }
+            })
         }
     }
 

--- a/app/src/main/java/com/halil/ozel/unsplashexample/ui/viewmodel/ImageViewModel.kt
+++ b/app/src/main/java/com/halil/ozel/unsplashexample/ui/viewmodel/ImageViewModel.kt
@@ -16,15 +16,22 @@ class ImageViewModel @Inject constructor(private val repository: ImageRepository
     private val _response = MutableLiveData<List<ImageItem>>()
     val responseImages: LiveData<List<ImageItem>> = _response
 
+    private val imageList = mutableListOf<ImageItem>()
+    private var currentPage = 1
+
     init {
-        getAllImages()
+        loadNextPage()
     }
 
-    private fun getAllImages() = viewModelScope.launch {
+    fun loadNextPage() = viewModelScope.launch {
         try {
-            val response = repository.getAllImages()
+            val response = repository.getImages(currentPage)
             if (response.isSuccessful) {
-                _response.postValue(response.body())
+                response.body()?.let { items ->
+                    imageList.addAll(items)
+                    _response.postValue(imageList.toList())
+                    currentPage++
+                }
             } else {
                 Log.e(TAG, "Error: ${'$'}{response.errorBody()}")
             }

--- a/app/src/main/java/com/halil/ozel/unsplashexample/utils/Constants.kt
+++ b/app/src/main/java/com/halil/ozel/unsplashexample/utils/Constants.kt
@@ -7,4 +7,5 @@ object Constants {
     const val VERSION = "v1"
     const val ACCEPT_VERSION = "Accept-Version"
     const val AUTHORIZATION = "Authorization: Client-ID"
+    const val PER_PAGE = 20
 }


### PR DESCRIPTION
## Summary
- support a `PER_PAGE` constant for pagination
- request images with paging parameters
- store loaded pages in `ImageViewModel` for subsequent loads
- add scroll listener to fetch more images while scrolling

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685f10a239f4832ba7175742aa9e3ec5